### PR TITLE
[TT-6024] : non querystring apikey (#10)

### DIFF
--- a/What3wordsSearchbox.php
+++ b/What3wordsSearchbox.php
@@ -3,7 +3,7 @@
 Plugin Name: what3words Autosuggest Plugin
 Plugin URI: https://github.com/what3words/wordpress-autosuggest-plugin
 Description: WordPress plugin to capture and validate what3word's 3 word addresses
-Version: 3.0.9
+Version: 3.0.10
 Author: what3words
 Author URI: http://what3words.com
 License: GPLv2
@@ -12,6 +12,7 @@ Text Domain: what3words-searchbox
 
 if (!defined('ABSPATH')) exit;
 
+define('WHAT3WORDS_PLUGIN_DIRNAME', array_pop(explode('/', __DIR__)));
 define('WHAT3WORDS_SEARCHBOX_URL', plugin_dir_url(__FILE__));
 define('WHAT3WORDS_SEARCHBOX_PATH', plugin_dir_path(__FILE__));
 define('WHAT3WORDS_SEARCHBOX_NAME', plugin_basename(__FILE__));
@@ -85,7 +86,6 @@ if (!class_exists('What3wordsSearchbox')) {
                         'api_key' => '',
                         'input_selectors' => '',
                         'input_placeholder' => 'e.g. `index.home.raft`',
-                    //    'color' => '#e11f26',
                         'woocommerce_enabled' => false
                     ]
                 );
@@ -98,7 +98,7 @@ if (!class_exists('What3wordsSearchbox')) {
          * "init" action hook; called to initialise the plugin
          */
         function init() {
-            $lang_dir = '3-word-address-validation-field/languages';
+            $lang_dir = WHAT3WORDS_PLUGIN_DIRNAME . '/languages';
             load_plugin_textdomain ('what3words-searchbox', false, $lang_dir);
         }
 
@@ -115,7 +115,7 @@ if (!class_exists('What3wordsSearchbox')) {
 
             //  This is the plugin script that loads web component
             $handle = 'what3words-searchbox-autosuggest-js';
-            $src = 'https://assets.what3words.com/sdk/v3.1/what3words.js?key=' . $settings['api_key'];
+            $src = 'https://assets.what3words.com/sdk/v3.1/what3words.js?';
             $deps = [];
             $ver = NULL;
             $in_footer = true;

--- a/What3wordsSearchboxAdmin.php
+++ b/What3wordsSearchboxAdmin.php
@@ -47,7 +47,7 @@ if (!class_exists('What3wordsSearchboxAdmin')) {
          * on the plugins page (beside the activate/deactivate links)
          */
         public function action_links($actions, $plugin_file, $plugin_data, $context) {
-            $settings = sprintf('<a href="%s">%s</a>', admin_url('options-general.php?page=3-word-address-validation-field/What3wordsSearchboxAdmin.php'),  __('Settings', 'what3words-searchbox'));
+            $settings = sprintf('<a href="%s">%s</a>', admin_url('options-general.php?page=' . WHAT3WORDS_PLUGIN_DIRNAME . '/What3wordsSearchboxAdmin.php'),  __('Settings', 'what3words-searchbox'));
             array_unshift($actions, $settings);
 
             return $actions;
@@ -110,7 +110,7 @@ if (!class_exists('What3wordsSearchboxAdmin')) {
                     }
 
                     if (!empty($notice)) {
-                        $notice[] = sprintf('You can go to the <a href="%s">What3words Searchbox Settings page</a> to do this now', admin_url('options-general.php?page=3-word-address-validation-field/What3wordsSearchboxAdmin.php'));
+                        $notice[] = sprintf('You can go to the <a href="%s">What3words Searchbox Settings page</a> to do this now', admin_url('options-general.php?page=' . WHAT3WORDS_PLUGIN_DIRNAME . '/What3wordsSearchboxAdmin.php'));
                         echo '<div class="error notice is-dismissible"><p>' . implode('. ', $notice) . '</p></div>';
                     }
                 }
@@ -192,7 +192,7 @@ if (!class_exists('What3wordsSearchboxAdmin')) {
             ?>
             <div class="wrap">
                 <h1><?php echo '<img src="https://assets.what3words.com/images/what3words_header_logo_261x43.png" /><br />' . esc_html(get_admin_page_title()); ?></h1>
-                <form method="post" action="<?php echo esc_html(admin_url('options-general.php?page=3-word-address-validation-field/What3wordsSearchboxAdmin.php')); ?>">
+                <form method="post" action="<?php echo esc_html(admin_url('options-general.php?page=' . WHAT3WORDS_PLUGIN_DIRNAME . '/What3wordsSearchboxAdmin.php')); ?>">
                     <div id="what3words-searchbox-wrap">
                         <h2><?php _e('what3words API Settings', 'what3words-searchbox'); ?></h2>
                         <div id="what3words-searchbox-api-wrap">
@@ -255,7 +255,7 @@ if (!class_exists('What3wordsSearchboxAdmin')) {
             $settings = $this->get_option();
 
             if (!empty($_POST['what3words-searchbox-submit'])) {
-                if (strstr($_GET['page'], '3-word-address-validation-field') && check_admin_referer('what3words-searchbox-save-settings', 'what3words-searchbox-nonce')) {
+                if (strstr($_GET['page'], WHAT3WORDS_PLUGIN_DIRNAME) && check_admin_referer('what3words-searchbox-save-settings', 'what3words-searchbox-nonce')) {
                     $settings['api_key'] = $this->option('what3words-searchbox-api-key');
                     $settings['input_selectors'] = $this->option('what3words-searchbox-input-selector');
                     $settings['input_placeholder'] = $this->option('what3words-searchbox-input-placeholder');

--- a/assets/js/what3words-searchbox-init.js
+++ b/assets/js/what3words-searchbox-init.js
@@ -48,6 +48,8 @@
       var w3wComponent = document.createElement('what3words-autosuggest')
       var targetParent = targetInput.parentNode
 
+      w3wComponent.setAttribute('api-key', What3wordsSearchbox.api_key)
+
       w3wComponent.headers = JSON.stringify({
         "X-W3W-Plugin":
           `what3words-Wordpress/${What3wordsSearchbox.w3_version} (` + [

--- a/readme.txt
+++ b/readme.txt
@@ -93,7 +93,11 @@ You can learn more about our privacy policy here: [what3words Privacy Policy](ht
 
 == Changelog ==
 
-The current version is 3.0.9 (2021.02.03)
+The current version is 3.0.10 (2021.03.09)
+
+= 3.0.10 =
+* Released 2021.03.09
+* Fixes passing API key to autosuggest for requests.
 
 = 3.0.9 =
 * Released 2021.02.03


### PR DESCRIPTION
* move api_key from the sdk script queryparam to the js init script, prevents Wordpress optimisers from dropping the key

* simpler to set via prop on component

* [TT-6024] feat(add plugin dirname resilience)

* chore(version bump for release and update changelog)

Co-authored-by: Gaz Jessep <gareth@what3words>
Co-authored-by: Christian Shaw <cxs.shaw@googlemail.com>