### PR TITLE
[TT-6471] Fix php variable assignment error

### DIFF
--- a/What3wordsSearchbox.php
+++ b/What3wordsSearchbox.php
@@ -3,7 +3,7 @@
 Plugin Name: what3words Autosuggest Plugin
 Plugin URI: https://github.com/what3words/wordpress-autosuggest-plugin
 Description: WordPress plugin to capture and validate what3word's 3 word addresses
-Version: 3.0.10
+Version: 3.0.11
 Author: what3words
 Author URI: http://what3words.com
 License: GPLv2
@@ -12,7 +12,8 @@ Text Domain: what3words-searchbox
 
 if (!defined('ABSPATH')) exit;
 
-define('WHAT3WORDS_PLUGIN_DIRNAME', array_pop(explode('/', __DIR__)));
+$plugin_dirs = explode('/', __DIR__);
+define('WHAT3WORDS_PLUGIN_DIRNAME', array_pop($plugin_dirs));
 define('WHAT3WORDS_SEARCHBOX_URL', plugin_dir_url(__FILE__));
 define('WHAT3WORDS_SEARCHBOX_PATH', plugin_dir_path(__FILE__));
 define('WHAT3WORDS_SEARCHBOX_NAME', plugin_basename(__FILE__));

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: what3words, 3 word address, three word address, searchbox, search, address
 Requires at least: 4.7
 Tested up to: 5.6
 Requires PHP: 5.4.2 or later
-Stable tag: 3.0.8
+Stable tag: 3.0.11
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Background

PHP was throwing an error due to the fact that `explode` was being passed directly as a parameter of the `array_pop` function, which causes an error because the return value of `explode` must be set against a variable before being passed to a function. See this [article](https://vijayasankarn.wordpress.com/2017/08/28/php-only-variables-should-be-passed-by-reference/) for more information/an example of where this occurs.

To fix this is now being set against a variable before being passed to the following function.

* Tested with PHP 7.3, WordPress 5.7.2 and MySQL 5.7
* Tested with `WP_DEBUG=true`
