### PR TITLE
[TT-7527] Only call is_checkout if WC installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,0 @@
-# Changelog
-
-## v4.0.0
-* Update Admin settings user interface
-* Added to item to WP menu
-* Update to Autosuggest component v4
-* Update WooCommerce order receipt customer integration
-* Add shipping 3wa to order preview modal

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
 
   wordpress:
-    image: 449290502274.dkr.ecr.eu-west-2.amazonaws.com/wordpress-testing-site:0.1.2
+    image: wordpress:5.9.0-php7.4-apache #449290502274.dkr.ecr.eu-west-2.amazonaws.com/wordpress-testing-site:0.1.2
     container_name: w3w-wp
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:80"]

--- a/test/cypress/integration/public/shop.steps.ts
+++ b/test/cypress/integration/public/shop.steps.ts
@@ -1,6 +1,0 @@
-import { Given } from 'cypress-cucumber-preprocessor/steps';
-
-Given('a customer has an item in their cart', () => {
-  cy.visit('/shop')
-    .get('a.button').click()
-});

--- a/w3w-autosuggest/README.txt
+++ b/w3w-autosuggest/README.txt
@@ -3,7 +3,7 @@ Contributors: what3words
 Tags: what3words, 3 word address, three word address, searchbox, search, address, validation, autosuggest, w3w
 Requires at least: 4.7
 Tested up to: 5.9
-Stable tag: 4.0.3
+Stable tag: 4.0.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -145,6 +145,10 @@ Have any questions? Want to learn more about how the what3words Address Field pl
 
 == Changelog ==
 
+= 4.0.4 =
+* Released 2022.05.31
+* Fixed critical error which surfaced when WooCommerce plugin is not installed
+
 = 4.0.3 =
 * Released 2022.05.03
 * Update to improve integration on checkout page with Fluid Checkout and other plugins.
@@ -259,16 +263,16 @@ Have any questions? Want to learn more about how the what3words Address Field pl
 
 == Upgrade Notice ==
 
+= 4.0.4 =
+Fixed critical error which surfaced when WooCommerce plugin is not installed
+
 = 4.0.3 =
-* Released 2022.05.03
 Improved integration with Fluid Checkout plugin for WooCommerce.
 
 = 4.0.2 =
-* Released 2022.04.21
 Fix bug where metadata wasn't sent to WooCommerce if applying autosuggest to an existing field.
 
 = 4.0.1 =
-* Released 2022.03.25
 Performance improvements and security vulnerability patch
 
 = 4.0 =

--- a/w3w-autosuggest/public/class-w3w-autosuggest-public.php
+++ b/w3w-autosuggest/public/class-w3w-autosuggest-public.php
@@ -107,6 +107,7 @@ class W3W_Autosuggest_Public {
     global $woocommerce;
 
     $settings = get_option( W3W_SETTINGS_NAME );
+    $has_woocommerce = class_exists( 'woocommerce' );
     $exposed_settings['version'] = $settings['version'];
     $exposed_settings['php_version'] = phpversion();
     $exposed_settings['wp_version'] = $wp_version;
@@ -114,10 +115,10 @@ class W3W_Autosuggest_Public {
     $exposed_settings['api_key'] = $settings['api_key'];
     // Determine if WordPress is running with WooCommerce enabled
     // https://woocommerce.com/document/query-whether-woocommerce-is-activated/
-    $exposed_settings['woocommerce_activated'] = class_exists( 'woocommerce' );
+    $exposed_settings['woocommerce_activated'] = $has_woocommerce;
     // Determine if current page is the WooCommerce checkout page
     // https://njengah.com/is-checkout-page-woocommerce/
-    $exposed_settings['woocommerce_checkout'] = is_checkout();
+    $exposed_settings['woocommerce_checkout'] = $has_woocommerce ? is_checkout() : false;
     if ( isset( $settings['woocommerce_enabled'] ) )
       $exposed_settings['woocommerce_enabled'] = $settings['woocommerce_enabled'];
     if ( isset( $settings['enable_placeholder'] ) )

--- a/w3w-autosuggest/public/class-w3w-autosuggest-public.php
+++ b/w3w-autosuggest/public/class-w3w-autosuggest-public.php
@@ -107,14 +107,14 @@ class W3W_Autosuggest_Public {
     global $woocommerce;
 
     $settings = get_option( W3W_SETTINGS_NAME );
+    // Determine if WordPress is running with WooCommerce enabled
+    // https://woocommerce.com/document/query-whether-woocommerce-is-activated/
     $has_woocommerce = class_exists( 'woocommerce' );
     $exposed_settings['version'] = $settings['version'];
     $exposed_settings['php_version'] = phpversion();
     $exposed_settings['wp_version'] = $wp_version;
     $exposed_settings['wc_version'] = isset( $woocommerce ) ? $woocommerce->version : 'N/A';
     $exposed_settings['api_key'] = $settings['api_key'];
-    // Determine if WordPress is running with WooCommerce enabled
-    // https://woocommerce.com/document/query-whether-woocommerce-is-activated/
     $exposed_settings['woocommerce_activated'] = $has_woocommerce;
     // Determine if current page is the WooCommerce checkout page
     // https://njengah.com/is-checkout-page-woocommerce/

--- a/w3w-autosuggest/w3w-autosuggest.php
+++ b/w3w-autosuggest/w3w-autosuggest.php
@@ -16,7 +16,7 @@
  * Plugin Name:       what3words Address Field
  * Plugin URI:        https://github.com/what3words/wordpress-autosuggest-plugin
  * Description:       Official plugin to allow customers to enter and validate a what3words address on your checkout for accurate deliveries
- * Version:           4.0.3
+ * Version:           4.0.4
  * Author:            what3words
  * Author URI:        https://what3words.com
  * License:           GPL-2.0+
@@ -55,7 +55,7 @@ if ( !defined( 'W3W_AUTOSUGGEST_PLUGIN_BASENAME' ) ) {
  * Current plugin version.
  */
 if ( !defined( 'W3W_PLUGIN_VERSION' ) ) {
-  define( 'W3W_PLUGIN_VERSION', '4.0.3' );
+  define( 'W3W_PLUGIN_VERSION', '4.0.4' );
 }
 /**
  * Plugin settings name


### PR DESCRIPTION
See [Jira](https://what3words.atlassian.net/browse/TT-7527) for more information

Worth noting that this wasn't picked up by our tests as the image we use for testing always has WC installed. This is also why no tests have been added for this too. I may in a subsequent task change the base image and install WC as part of a setup `before` hook or as a Cypress `task`, but it poses problems as it's not so simple to clean up afterwards in teardown to get back to the initial state.