### PR TITLE
IN-674 Bug fix - return_coordinates is always true

### DIFF
--- a/w3w-autosuggest/CHANGELOG.txt
+++ b/w3w-autosuggest/CHANGELOG.txt
@@ -1,3 +1,7 @@
+= 4.0.11 =
+* Release 2024.05.16
+* Fixed a bug that overrides return_coordinates value (always set to true)
+
 = 4.0.10 =
 * Release 2024.02.08
 * Updated autosuggest component from version 4.0.6 to 4.2.2

--- a/w3w-autosuggest/README.txt
+++ b/w3w-autosuggest/README.txt
@@ -3,7 +3,7 @@ Contributors: what3words
 Tags: what3words, 3 word address, three word address, searchbox, search, address, validation, autosuggest, w3w
 Requires at least: 4.7
 Tested up to: 6.4
-Stable tag: 4.0.10
+Stable tag: 4.0.11
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -73,6 +73,10 @@ Have any questions? Want to learn more about how the what3words Address Field pl
 4. Pass on what3words addresses to our delivery partners DHL, DPD, Evri and Yodel
 
 == Changelog ==
+
+= 4.0.11 =
+* Release 2024.05.16
+* Fixed a bug that overrides return_coordinates value (always set to true)
 
 = 4.0.10 =
 * Release 2024.02.08

--- a/w3w-autosuggest/public/js/w3w-autosuggest-public.js
+++ b/w3w-autosuggest/public/js/w3w-autosuggest-public.js
@@ -263,7 +263,6 @@ let components = [];
 
     const targets = document.querySelectorAll(selector);
     const _components = attachComponentToTargets(targets);
-    const [component] = _components;
     attachLabelToComponents(_components);
 
     targets.forEach((target, index) => {
@@ -482,7 +481,7 @@ let components = [];
       })
     );
     w3wComponent.setAttribute('api_key', api_key);
-    w3wComponent.setAttribute('return_coordinates', true);
+    w3wComponent.setAttribute('return_coordinates', return_coordinates);
 
     if (enable_clip_to_country && clip_to_country) {
       w3wComponent.setAttribute('clip_to_country', clip_to_country);

--- a/w3w-autosuggest/w3w-autosuggest.php
+++ b/w3w-autosuggest/w3w-autosuggest.php
@@ -16,7 +16,7 @@
  * Plugin Name:       what3words Address Field
  * Plugin URI:        https://github.com/what3words/wordpress-autosuggest-plugin
  * Description:       Official plugin to allow customers to enter and validate a what3words address on your checkout for accurate deliveries
- * Version:           4.0.10
+ * Version:           4.0.11
  * Author:            what3words
  * Author URI:        https://what3words.com
  * License:           GPL-2.0+


### PR DESCRIPTION
`return_coordinates` which is the setting used to determine if we need to invoke convert to coordinates after selecting an autosuggest result is always `true` which uses up our partner's API limit.