### PR TITLE
[TT-9574] Save coordinates note update

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Pull request
+name: Run tests
 
 on:
   pull_request:
@@ -49,3 +49,7 @@ jobs:
           name: Recordings
           path: ./test/cypress/videos/**/*.mp4
           if-no-files-found: ignore
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Run tests
+name: Pull request
 
 on:
   pull_request:

--- a/w3w-autosuggest/CHANGELOG.txt
+++ b/w3w-autosuggest/CHANGELOG.txt
@@ -1,3 +1,7 @@
+= 4.0.14 =
+* Release 2024.09.03
+* Updated the notes on save coordinates option in settings page
+
 = 4.0.13 =
 * Release 2024.08.28
 * Updated autosuggest component from version 4.8.0 to 4.9.0

--- a/w3w-autosuggest/README.txt
+++ b/w3w-autosuggest/README.txt
@@ -3,7 +3,7 @@ Contributors: what3words
 Tags: what3words, 3 word address, three word address, searchbox, search, address, validation, autosuggest, w3w
 Requires at least: 4.7
 Tested up to: 6.4
-Stable tag: 4.0.13
+Stable tag: 4.0.14
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -73,6 +73,10 @@ Have any questions? Want to learn more about how the what3words Address Field pl
 4. Pass on what3words addresses to our delivery partners DHL, DPD, Evri and Yodel
 
 == Changelog ==
+
+= 4.0.14 =
+* Release 2024.09.03
+* Updated the notes on save coordinates option in settings page
 
 = 4.0.13 =
 * Release 2024.08.28

--- a/w3w-autosuggest/admin/partials/w3w-autosuggest-settings.php
+++ b/w3w-autosuggest/admin/partials/w3w-autosuggest-settings.php
@@ -81,7 +81,7 @@
               Save coordinates
               <div class="fw-light fst-italic small">
                 This will save the GPS coordinates of the what3words address and display them in the Order Details page.<br />
-                NOTE: This will make additional calls to the what3words API using the <span class="fw-bold">convert-to-coordinates</span> function.
+                <span class="fw-bold">NOTE:</span> This feature won't work if you're on a free plan or have exceeded your quota. Check the console and network panel for errors. No coordinates will be saved. Please review our <a href="https://accounts.what3words.com/select-plan">plans</a> for higher allowances.
               </div>
             </div>
           </label>

--- a/w3w-autosuggest/w3w-autosuggest.php
+++ b/w3w-autosuggest/w3w-autosuggest.php
@@ -16,7 +16,7 @@
  * Plugin Name:       what3words Address Field
  * Plugin URI:        https://github.com/what3words/wordpress-autosuggest-plugin
  * Description:       Official plugin to allow customers to enter and validate a what3words address on your checkout for accurate deliveries
- * Version:           4.0.13
+ * Version:           4.0.14
  * Author:            what3words
  * Author URI:        https://what3words.com
  * License:           GPL-2.0+
@@ -55,7 +55,7 @@ if (!defined('W3W_AUTOSUGGEST_PLUGIN_BASENAME')) {
  * Current plugin version.
  */
 if (!defined('W3W_PLUGIN_VERSION')) {
-  define('W3W_PLUGIN_VERSION', '4.0.13');
+  define('W3W_PLUGIN_VERSION', '4.0.14');
 }
 /**
  * Plugin settings name


### PR DESCRIPTION
Updated the NOTE on save coordinates options on the settings page:

![image](https://github.com/user-attachments/assets/88c4c416-dbc9-4142-a164-f0bb730df3d4)
